### PR TITLE
Change package names due to npm registry restrictions

### DIFF
--- a/apps/www/components/Aside/Content.tsx
+++ b/apps/www/components/Aside/Content.tsx
@@ -1,6 +1,6 @@
 import styles from "./aside.module.scss";
+import { useTypetools } from "@pulipola/typetools";
 import { InputFont } from "components/FontInput";
-import { useTypetools } from "typetools";
 import { FontData } from "./FontData";
 import { ProjectInfo } from "./ProjectInfo";
 import { FontSelector } from "components/FontSelector";

--- a/apps/www/components/Aside/FontData.tsx
+++ b/apps/www/components/Aside/FontData.tsx
@@ -1,4 +1,4 @@
-import { Font } from "typetools";
+import { Font } from "@pulipola/typetools";
 import { TreeView } from "components/TreeView";
 
 type FontDataProps = {

--- a/apps/www/components/FontInput/index.tsx
+++ b/apps/www/components/FontInput/index.tsx
@@ -1,6 +1,6 @@
 import styles from "./input.module.scss";
 import { ChangeEvent, FormEvent, useRef, useState } from "react";
-import { useTypetools } from "typetools";
+import { useTypetools } from "@pulipola/typetools";
 
 export const InputFont = () => {
     const refInput = useRef<HTMLInputElement>(null);

--- a/apps/www/components/FontSelector/index.tsx
+++ b/apps/www/components/FontSelector/index.tsx
@@ -1,6 +1,6 @@
 import { CSSProperties, useRef } from "react";
 import { useOnClickOutside } from "@pulipola/hook";
-import { useTypetools } from "typetools";
+import { useTypetools } from "@pulipola/typetools";
 import { useToggle } from "lib/hooks/useToggle";
 
 export const FontSelector = () => {

--- a/apps/www/components/Glyph/index.tsx
+++ b/apps/www/components/Glyph/index.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useGlyph, useTypetools, useVariable } from "typetools";
+import { useGlyph, useTypetools, useVariable } from "@pulipola/typetools";
 import { Grid } from "components/Layouts";
 import { TypetesterController } from "components/Typetester/Controller";
 

--- a/apps/www/components/Typetester/Controller.tsx
+++ b/apps/www/components/Typetester/Controller.tsx
@@ -1,6 +1,6 @@
 import styles from "./controller.module.scss";
 import { CSSProperties, useMemo } from "react";
-import { Controller, ControllerTag, Axes } from "typetools";
+import { Controller, ControllerTag, Axes } from "@pulipola/typetools";
 import { Slider } from "components/Utils/Slider";
 // import { event } from "lib/gtag";
 interface TypetesterControllerProps {

--- a/apps/www/components/Typetester/index.tsx
+++ b/apps/www/components/Typetester/index.tsx
@@ -1,6 +1,6 @@
 import editStyle from "./editable.module.scss";
 import Editable from "react-contenteditable";
-import { useTypetester, useVariable, useTypetools } from "typetools";
+import { useTypetester, useVariable, useTypetools } from "@pulipola/typetools";
 import { Grid } from "components/Layouts";
 import { TypetesterController } from "./Controller";
 

--- a/apps/www/lib/context/index.tsx
+++ b/apps/www/lib/context/index.tsx
@@ -1,5 +1,5 @@
 import { FC } from "react";
-import { ProviderTypetools } from "typetools";
+import { ProviderTypetools } from "@pulipola/typetools";
 import { ProviderTheme } from "@pulipola/ui";
 
 const defaultFonts = [

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@pulipola/typetools",
+    "name": "pulipola-typetools",
     "version": "1.0.4",
     "description": "Typetools",
     "author": "Taufik Oktama",
@@ -19,6 +19,7 @@
         "@pulipola/hook": "^1.0.0-alpha.1",
         "@pulipola/opentype": "^0.0.1",
         "@pulipola/typetester": "^0.0.2",
+        "@pulipola/typetools": "*",
         "@pulipola/ui": "^1.0.0-alpha.0",
         "next": "^10.0.7",
         "opentype.js": "^1.3.3",
@@ -26,8 +27,7 @@
         "react-contenteditable": "^3.3.5",
         "react-dom": "^17.0.1",
         "react-spring": "^8.0.27",
-        "sass": "^1.32.7",
-        "typetools": "^0.0.2"
+        "sass": "^1.32.7"
     },
     "devDependencies": {
         "@types/node": "^14.14.28",

--- a/packages/typetools/package.json
+++ b/packages/typetools/package.json
@@ -1,21 +1,24 @@
 {
-    "name": "typetools",
+    "name": "@pulipola/typetools",
     "version": "0.0.2",
     "description": "Typetools",
     "keywords": [
         "typetools"
     ],
-    "author": "ottta <oktamataufik@gmail.com>",
-    "homepage": "https://github.com/pulipola/pulipola-typetools#readme",
+    "author": "Taufik Oktama <oktamataufik@gmail.com>",
+    "homepage": "https://github.com/pulipola/pulipola-typetools/blob/main/packages/typetools/README.md",
     "license": "MIT",
     "main": "dist/index",
     "types": "dist/index",
     "files": [
         "dist"
     ],
+    "publishConfig": {
+        "access": "public"
+    },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/pulipola/pulipola-typetools.git"
+        "url": "git+https://github.com/pulipola/pulipola-typetools/tree/main/packages/typetools"
     },
     "scripts": {
         "build": "yarn run clean && yarn run compile",


### PR DESCRIPTION
- packages/typetools: "typetools" > "@pulipola/typetools"
- apps/www "@pulipola/typetools" > "pulipola-typetools"